### PR TITLE
Extend Snakemake / Python support window and tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: |
+            3.9
+            3.10
             3.11
             3.12
       - name: Install nox

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,18 +1,17 @@
-import os
 import nox
 
 
-@nox.session(python="3.11")
+@nox.session(python=["3.9", "3.10", "3.11", "3.12"])
 def snakemake7(session):
-    """Test Snakemake 7 with Python 3.11."""
+    """Test Snakemake 7"""
     session.install("snakemake<8", "pulp<2.8", "pytest", ".")
     session.run("pytest")
     session.run("bash", "tests/run_tests.sh", external=True)
 
 
-@nox.session(python="3.12")
+@nox.session(python=["3.12"])
 def snakemake8(session):
-    """Test Snakemake 8 with Python 3.12."""
+    """Test Snakemake 8"""
     session.install("snakemake<9", "pytest", ".")
     session.run("pytest")
     session.run("bash", "tests/run_tests.sh", external=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "grapevne"
 version = "0.1.0"
-description = ""
+description = "Python library for grapevne snakemake support"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.9"
 dependencies = [
     "packaging>=24.1",
 ]


### PR DESCRIPTION
Extend support to Snakemake 7 (Python 3.9+). Extend noxfile to cover test window.