### PR TITLE
Update test workflows to use grapevne_helper

### DIFF
--- a/tests/test-repo/workflows/testing/modules/concat/workflow/Snakefile
+++ b/tests/test-repo/workflows/testing/modules/concat/workflow/Snakefile
@@ -1,7 +1,7 @@
 """Concatenate the contents of two files from different ports and write to a single file."""
 configfile: "config/config.yaml"
 
-from grapevne.helpers import grapevne_helper
+from grapevne_helper import grapevne_helper
 import shutil
 
 with grapevne_helper(globals()):

--- a/tests/test-repo/workflows/testing/modules/concat/workflow/grapevne_helper.py
+++ b/tests/test-repo/workflows/testing/modules/concat/workflow/grapevne_helper.py
@@ -1,0 +1,24 @@
+import sys
+import logging
+
+try:
+    from grapevne.helpers import *  # noqa: F403
+except ImportError:
+    import ensurepip
+    import subprocess
+
+    ensurepip.bootstrap()
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--upgrade", "grapevne"]
+    )
+    try:
+        from grapevne.helpers import *  # noqa: F403 F401
+    except ImportError:
+        logging.error("Failed to install grapevne. Exiting.")
+        sys.exit(1)
+
+# Tidy-up namespace
+del sys, logging
+
+# Dynamically export all names imported from grapevne
+__all__ = [name for name in dir() if not name.startswith("_")]

--- a/tests/test-repo/workflows/testing/modules/copy/workflow/Snakefile
+++ b/tests/test-repo/workflows/testing/modules/copy/workflow/Snakefile
@@ -4,7 +4,7 @@ This file also demonstrates the use of the `init`, `input`, `output`, `script`, 
 """
 configfile: "config/config.yaml"
 
-from grapevne.helpers import *
+from grapevne_helper import *
 import shutil
 
 init(workflow, config)

--- a/tests/test-repo/workflows/testing/modules/copy/workflow/grapevne_helper.py
+++ b/tests/test-repo/workflows/testing/modules/copy/workflow/grapevne_helper.py
@@ -1,0 +1,24 @@
+import sys
+import logging
+
+try:
+    from grapevne.helpers import *  # noqa: F403
+except ImportError:
+    import ensurepip
+    import subprocess
+
+    ensurepip.bootstrap()
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--upgrade", "grapevne"]
+    )
+    try:
+        from grapevne.helpers import *  # noqa: F403 F401
+    except ImportError:
+        logging.error("Failed to install grapevne. Exiting.")
+        sys.exit(1)
+
+# Tidy-up namespace
+del sys, logging
+
+# Dynamically export all names imported from grapevne
+__all__ = [name for name in dir() if not name.startswith("_")]

--- a/tests/test-repo/workflows/testing/modules/copy_gv_context/workflow/Snakefile
+++ b/tests/test-repo/workflows/testing/modules/copy_gv_context/workflow/Snakefile
@@ -4,7 +4,7 @@ This version demonstrates use of Helper as a context manager.
 """
 configfile: "config/config.yaml"
 
-from grapevne.helpers import grapevne_helper
+from grapevne_helper import grapevne_helper
 import shutil
 
 

--- a/tests/test-repo/workflows/testing/modules/copy_gv_context/workflow/grapevne_helper.py
+++ b/tests/test-repo/workflows/testing/modules/copy_gv_context/workflow/grapevne_helper.py
@@ -1,0 +1,24 @@
+import sys
+import logging
+
+try:
+    from grapevne.helpers import *  # noqa: F403
+except ImportError:
+    import ensurepip
+    import subprocess
+
+    ensurepip.bootstrap()
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--upgrade", "grapevne"]
+    )
+    try:
+        from grapevne.helpers import *  # noqa: F403 F401
+    except ImportError:
+        logging.error("Failed to install grapevne. Exiting.")
+        sys.exit(1)
+
+# Tidy-up namespace
+del sys, logging
+
+# Dynamically export all names imported from grapevne
+__all__ = [name for name in dir() if not name.startswith("_")]

--- a/tests/test-repo/workflows/testing/modules/copy_gv_namespace/workflow/Snakefile
+++ b/tests/test-repo/workflows/testing/modules/copy_gv_namespace/workflow/Snakefile
@@ -4,7 +4,7 @@ This version demonstrates use of the helper by importing function names ('script
 """
 configfile: "config/config.yaml"
 
-from grapevne.helpers import *
+from grapevne_helper import *
 import shutil
 
 init(workflow, config)

--- a/tests/test-repo/workflows/testing/modules/copy_gv_namespace/workflow/grapevne_helper.py
+++ b/tests/test-repo/workflows/testing/modules/copy_gv_namespace/workflow/grapevne_helper.py
@@ -1,0 +1,24 @@
+import sys
+import logging
+
+try:
+    from grapevne.helpers import *  # noqa: F403
+except ImportError:
+    import ensurepip
+    import subprocess
+
+    ensurepip.bootstrap()
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--upgrade", "grapevne"]
+    )
+    try:
+        from grapevne.helpers import *  # noqa: F403 F401
+    except ImportError:
+        logging.error("Failed to install grapevne. Exiting.")
+        sys.exit(1)
+
+# Tidy-up namespace
+del sys, logging
+
+# Dynamically export all names imported from grapevne
+__all__ = [name for name in dir() if not name.startswith("_")]

--- a/tests/test-repo/workflows/testing/modules/copy_gv_object/workflow/Snakefile
+++ b/tests/test-repo/workflows/testing/modules/copy_gv_object/workflow/Snakefile
@@ -4,7 +4,7 @@ This version demonstrates use of the grapevne helper using the object instance.
 """
 configfile: "config/config.yaml"
 
-from grapevne.helpers import Helper
+from grapevne_helper import Helper
 import shutil
 
 gv = Helper(workflow, config)

--- a/tests/test-repo/workflows/testing/modules/copy_gv_object/workflow/grapevne_helper.py
+++ b/tests/test-repo/workflows/testing/modules/copy_gv_object/workflow/grapevne_helper.py
@@ -1,0 +1,24 @@
+import sys
+import logging
+
+try:
+    from grapevne.helpers import *  # noqa: F403
+except ImportError:
+    import ensurepip
+    import subprocess
+
+    ensurepip.bootstrap()
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--upgrade", "grapevne"]
+    )
+    try:
+        from grapevne.helpers import *  # noqa: F403 F401
+    except ImportError:
+        logging.error("Failed to install grapevne. Exiting.")
+        sys.exit(1)
+
+# Tidy-up namespace
+del sys, logging
+
+# Dynamically export all names imported from grapevne
+__all__ = [name for name in dir() if not name.startswith("_")]

--- a/tests/test-repo/workflows/testing/sources/touch/workflow/Snakefile
+++ b/tests/test-repo/workflows/testing/sources/touch/workflow/Snakefile
@@ -1,7 +1,7 @@
 """Create an empty file"""
 configfile: "config/config.yaml"
 
-from grapevne.helpers import grapevne_helper
+from grapevne_helper import grapevne_helper
 from pathlib import Path
 
 with grapevne_helper(globals()):

--- a/tests/test-repo/workflows/testing/sources/touch/workflow/grapevne_helper.py
+++ b/tests/test-repo/workflows/testing/sources/touch/workflow/grapevne_helper.py
@@ -1,0 +1,24 @@
+import sys
+import logging
+
+try:
+    from grapevne.helpers import *  # noqa: F403
+except ImportError:
+    import ensurepip
+    import subprocess
+
+    ensurepip.bootstrap()
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--upgrade", "grapevne"]
+    )
+    try:
+        from grapevne.helpers import *  # noqa: F403 F401
+    except ImportError:
+        logging.error("Failed to install grapevne. Exiting.")
+        sys.exit(1)
+
+# Tidy-up namespace
+del sys, logging
+
+# Dynamically export all names imported from grapevne
+__all__ = [name for name in dir() if not name.startswith("_")]


### PR DESCRIPTION
Test workflows now use `import grapevne_helper`, a local file included with each grapevne workflow. This will install `grapevne` from PyPI and re-export `__all__` in order to make the package available on systems where `grapevne` may not be natively installed.