### PR TITLE
Drop redundant 'config' from initialiser

### DIFF
--- a/grapevne/helpers/helpers.py
+++ b/grapevne/helpers/helpers.py
@@ -19,9 +19,9 @@ except ImportError:
 class Helper:
     snakemake_version = Version(snakemake.__version__)
 
-    def __init__(self, workflow=None, config=None):
+    def __init__(self, workflow=None):
         self.workflow = workflow
-        self.config = config
+        self.config = workflow.config if workflow else None
 
     def _check_config(self):
         if self.config is None:
@@ -148,9 +148,7 @@ class Helper:
 @contextmanager
 def grapevne_helper(globals_dict):
     workflow = globals_dict.get("workflow", None)
-    config = globals_dict.get("config", None)
-
-    gv = Helper(workflow, config)
+    gv = Helper(workflow)
 
     globals_dict["script"] = gv.script
     globals_dict["resource"] = gv.resource
@@ -175,9 +173,9 @@ def grapevne_helper(globals_dict):
 _helper = Helper()
 
 
-def init(workflow=None, config=None):
+def init(workflow=None):
     _helper.workflow = workflow
-    _helper.config = config
+    _helper.config = workflow.config if workflow else None
     _helper.snakemake_version = Version(snakemake.__version__)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,10 @@ dependencies = [
     "packaging>=24.1",
 ]
 
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [tool.uv]
 dev-dependencies = [
     "nox>=2024.4.15",

--- a/tests/test-repo/workflows/testing/modules/copy/workflow/Snakefile
+++ b/tests/test-repo/workflows/testing/modules/copy/workflow/Snakefile
@@ -7,7 +7,7 @@ configfile: "config/config.yaml"
 from grapevne.helpers import *
 import shutil
 
-init(workflow, config)
+init(workflow)
 
 rule copy:
     input:

--- a/tests/test-repo/workflows/testing/modules/copy_gv_namespace/workflow/Snakefile
+++ b/tests/test-repo/workflows/testing/modules/copy_gv_namespace/workflow/Snakefile
@@ -7,7 +7,7 @@ configfile: "config/config.yaml"
 from grapevne.helpers import *
 import shutil
 
-init(workflow, config)
+init(workflow)
 
 rule copy:
     input:

--- a/tests/test-repo/workflows/testing/modules/copy_gv_object/workflow/Snakefile
+++ b/tests/test-repo/workflows/testing/modules/copy_gv_object/workflow/Snakefile
@@ -7,7 +7,7 @@ configfile: "config/config.yaml"
 from grapevne.helpers import Helper
 import shutil
 
-gv = Helper(workflow, config)
+gv = Helper(workflow)
 
 rule copy:
     input:

--- a/tests/test_grapevne.py
+++ b/tests/test_grapevne.py
@@ -4,8 +4,13 @@ from pathlib import Path
 import pytest
 
 
+class Workflow:
+    def __init__(self, config):
+        self.config = config
+
+
 def test_script():
-    init(None, None)
+    init()
     with mock.patch(
         "grapevne.helpers.helpers.Helper._workflow_path",
         lambda self, path: Path("workflows") / path,
@@ -14,7 +19,7 @@ def test_script():
 
 
 def test_resource():
-    init(None, None)
+    init()
     with mock.patch(
         "grapevne.helpers.helpers.Helper._workflow_path",
         lambda self, path: Path("workflows") / path,
@@ -23,63 +28,63 @@ def test_resource():
 
 
 def test_input_single():
-    config = {
+    workflow = Workflow({
         "input_namespace": "in",
-    }
-    init(None, config)
+    })
+    init(workflow)
     assert Path(input("infile.txt")) == Path("results/in/infile.txt")
 
 
 def test_input_multi():
-    config = {
+    workflow = Workflow({
         "input_namespace": {
             "port1": "in1",
             "port2": "in2",
         },
-    }
-    init(None, config)
+    })
+    init(workflow)
     assert Path(input("infile1.txt", "port1")) == Path("results/in1/infile1.txt")
     assert Path(input("infile2.txt", "port2")) == Path("results/in2/infile2.txt")
 
 
 def test_output():
-    config = {
+    workflow = Workflow({
         "output_namespace": "out",
-    }
-    init(None, config)
+    })
+    init(workflow)
     assert Path(output("outfile.txt")) == Path("results/out/outfile.txt")
 
 
 def test_log():
-    init(None, None)
+    init()
     assert log("rule.log") == "logs/rule.log"
 
 
 def test_env():
-    init(None, None)
+    init()
     assert env("conda.yaml") == "envs/conda.yaml"
 
 
 def test_params():
-    config = {
+    workflow = Workflow({
         "params": {
             "param1": "value1",
             "param2": {
                 "param3": "value3",
             },
         },
-    }
-    init(None, config)
+    })
+    init(workflow)
     assert params("param1") == "value1"
     assert params("param2", "param3") == "value3"
 
 
 def test_params_notfound():
-    config = {
+    workflow = Workflow({
         "params": {
             "param1": "value1",
         },
-    }
-    init(None, config)
+    })
+    init(workflow)
     with pytest.raises(ValueError):
         params("param2")


### PR DESCRIPTION
`init(workflow, config)` is redundant since `config` is accessible through the `Workflow` class. Replaced with `init(workflow)`.