### PR TITLE
Alias 'param' to 'params'

### DIFF
--- a/grapevne/helpers/__init__.py
+++ b/grapevne/helpers/__init__.py
@@ -7,4 +7,5 @@ from .helpers import input  # noqa: F401
 from .helpers import output  # noqa: F401
 from .helpers import log  # noqa: F401
 from .helpers import env  # noqa: F401
+from .helpers import param  # noqa: F401
 from .helpers import params  # noqa: F401

--- a/grapevne/helpers/helpers.py
+++ b/grapevne/helpers/helpers.py
@@ -88,7 +88,10 @@ class Helper:
         elif isinstance(input_namespace, dict):
             indir = self.config["input_namespace"].get(port, None)
         else:
-            raise ValueError("Snakemake config error - Input namespace type not recognised")
+            raise ValueError(
+                "Snakemake config error - "
+                "Input namespace type not recognised"
+            )
         if not indir:
             raise ValueError("Attempting to read from a non-configured input port")
         if path:
@@ -130,7 +133,7 @@ class Helper:
             *args:  The path to the parameter in the configuration
                     Example: params("foo", "bar") will return the value of
                         config["params"]["foo"]["bar"]
-                    If no arguments are provided, the entire params dictionary is returned
+                    If no arguments are provided, return the entire params dictionary
         """
         self._check_config()
         if len(args) == 0:
@@ -144,6 +147,11 @@ class Helper:
             value = value.get(arg, {})
         return value
 
+    # Alias function - 'params' is the Snakefile directive, but 'param' is more
+    # intuitive and consistent with other helper functions.
+    def param(self, *args):
+        return self.params(*args)
+
 
 @contextmanager
 def grapevne_helper(globals_dict):
@@ -156,6 +164,7 @@ def grapevne_helper(globals_dict):
     globals_dict["output"] = gv.output
     globals_dict["log"] = gv.log
     globals_dict["env"] = gv.env
+    globals_dict["param"] = gv.param
     globals_dict["params"] = gv.params
 
     try:
@@ -212,6 +221,10 @@ def log(path):
 def env(path):
     """Return the path to an environment file"""
     return _helper.env(path)
+
+
+def param(*args):
+    return _helper.param(*args)
 
 
 def params(*args):

--- a/tests/test_grapevne.py
+++ b/tests/test_grapevne.py
@@ -1,4 +1,4 @@
-from grapevne.helpers import init, script, resource, input, output, log, env, params
+from grapevne.helpers import init, script, resource, input, output, log, env, param, params
 from unittest import mock
 from pathlib import Path
 import pytest
@@ -63,6 +63,31 @@ def test_log():
 def test_env():
     init()
     assert env("conda.yaml") == "envs/conda.yaml"
+
+
+def test_param():
+    workflow = Workflow({
+        "params": {
+            "param1": "value1",
+            "param2": {
+                "param3": "value3",
+            },
+        },
+    })
+    init(workflow)
+    assert param("param1") == "value1"
+    assert param("param2", "param3") == "value3"
+
+
+def test_param_notfound():
+    workflow = Workflow({
+        "params": {
+            "param1": "value1",
+        },
+    })
+    init(workflow)
+    with pytest.raises(ValueError):
+        param("param2")
 
 
 def test_params():


### PR DESCRIPTION
The grapevne helper functions mimic Snakemake's directives in most instances. For example, `input`, `output`, `log`. However, `params` is plural and does not fit syntactically with the other functions (such as `resource` or `script`). To remain compatible with both, `param` is added as an alias to `params`. 