### PR TITLE
Migrate to uv github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: |
+            3.9
+            3.10
+            3.11
+            3.12
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v2
-      - name: Install Python
-        run: uv python install 3.9 3.10 3.11 3.12
       - name: Install nox
         run: |
           uv tool install nox

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-12, macos-14, windows-latest]
 
+    env:
+      NOX_DEFAULT_VENV_BACKEND: uv
+
     steps:
       - uses: actions/checkout@v4
       - name: Install the latest version of uv
@@ -24,7 +27,5 @@ jobs:
         run: |
           uv tool install nox
       - name: Run tests
-        env:
-          NOX_DEFAULT_VENV_BACKEND=uv
         run: |
           uv tool run nox

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,5 +24,7 @@ jobs:
         run: |
           uv tool install nox
       - name: Run tests
+        env:
+          NOX_DEFAULT_VENV_BACKEND=uv
         run: |
           uv tool run nox

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,18 +16,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: |
-            3.9
-            3.10
-            3.11
-            3.12
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v2
+      - name: Install Python
+        run: uv python install 3.9 3.10 3.11 3.12
       - name: Install nox
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install nox
+          uv tool install nox
       - name: Run tests
         run: |
-          nox
+          uv tool run nox


### PR DESCRIPTION
Migrate from `setup-python` github action to `setup-uv` (which can be used to install multiple python versions under uv management).