### PR TITLE
Support short-form parameter indexing

### DIFF
--- a/grapevne/helpers/helpers.py
+++ b/grapevne/helpers/helpers.py
@@ -132,12 +132,19 @@ class Helper:
             *args:  The path to the parameter in the configuration
                     Example: params("foo", "bar") will return the value of
                         config["params"]["foo"]["bar"]
+                    You can also use the shorthand params("foo.bar"), so long as a
+                    unique key "foo.bar" does not already exist.
                     If no arguments are provided, return the entire params dictionary
         """
         self._check_config()
         if len(args) == 0:
             return self.config.get("params", {})
         value = self.config.get("params", {})
+        # Check if the argument is a dot-separated string
+        if len(args) == 1:
+            if args[0] not in value:
+                args = args[0].split(".")
+        # Iterate through the arguments
         for arg in args:
             if not isinstance(value, dict):
                 raise ValueError(f"Attempting to index a non-indexable value: {value}")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -93,8 +93,12 @@ def test_param():
         }
     )
     init(workflow)
-    assert param("param1") == "value1"
-    assert param("param2", "param3") == "value3"
+    # Single value
+    assert params("param1") == "value1"
+    # Long-form (comma-separated arguments)
+    assert params("param2", "param3") == "value3"
+    # Short-hand (dot-separated string)
+    assert params("param2.param3") == "value3"
 
 
 def test_param_notfound():
@@ -122,8 +126,12 @@ def test_params():
         }
     )
     init(workflow)
+    # Single value
     assert params("param1") == "value1"
+    # Long-form (comma-separated arguments)
     assert params("param2", "param3") == "value3"
+    # Short-hand (dot-separated string)
+    assert params("param2.param3") == "value3"
 
 
 def test_params_notfound():


### PR DESCRIPTION
Support short-form parameter indexing, whereby `params("param1.param2")` can be used as short-form for `params("param1", "param2')`, so long as "param1.param2" does not exist as a unique key. This returns `config["params"]["param1"]["param2"]` from the configuration file.